### PR TITLE
fix: guard against empty charge sessions array

### DIFF
--- a/lib/OhmeApi.ts
+++ b/lib/OhmeApi.ts
@@ -198,6 +198,13 @@ export class OhmeApi extends EventEmitter {
 
     for (let attempt = 0; attempt < 3; attempt++) {
       const sessions = await this.request<any[]>('GET', '/v1/chargeSessions');
+
+      if (!sessions || sessions.length === 0) {
+        this._chargeSession = { mode: 'DISCONNECTED' };
+        this._available = false;
+        return;
+      }
+
       resp = sessions[0];
 
       if (resp.mode !== 'CALCULATING' && resp.mode !== 'DELIVERING') {


### PR DESCRIPTION
## Summary
- Adds a guard in `OhmeApi.getChargeSession()` to handle cases where the API returns an empty or undefined sessions array
- When no sessions exist, resets charge session to `DISCONNECTED` and marks the charger as unavailable, preventing a TypeError crash on `sessions[0]` access

## Test plan
- [ ] Verify `getChargeSession()` handles an empty `[]` response without crashing
- [ ] Verify `getChargeSession()` handles an `undefined`/`null` response without crashing
- [ ] Verify normal charge session fetching still works as expected

Closes #2