### PR TITLE
fix: narrow Go driver model matching to avoid false positives

### DIFF
--- a/drivers/ohme-go/driver.ts
+++ b/drivers/ohme-go/driver.ts
@@ -2,4 +2,9 @@ import { OhmeDriver } from '../../lib/OhmeDriver';
 
 module.exports = class OhmeGoDriver extends OhmeDriver {
   protected modelPatterns = ['Go'];
+
+  protected matchesModel(displayName: string): boolean {
+    const lower = displayName.toLowerCase();
+    return lower.includes('go') && !lower.includes('pro');
+  }
 };


### PR DESCRIPTION
## Summary

- Adds a custom `matchesModel` override to the Go driver that excludes models containing "pro", matching the pattern already used by the Home driver
- Prevents the broad `includes('go')` check from matching hypothetical future models like "Go Pro"

Closes #9