### PR TITLE
fix: add onUninit to clear timers during app restarts

### DIFF
--- a/lib/OhmeDevice.ts
+++ b/lib/OhmeDevice.ts
@@ -195,6 +195,14 @@ export class OhmeDevice extends Device {
   // ── Lifecycle ──────────────────────────────────────────────────────
 
   async onDeleted(): Promise<void> {
+    this.clearIntervals();
+  }
+
+  async onUninit(): Promise<void> {
+    this.clearIntervals();
+  }
+
+  private clearIntervals(): void {
     if (this.sessionInterval) {
       clearInterval(this.sessionInterval);
     }


### PR DESCRIPTION
## Summary
- Extracts interval cleanup into a `clearIntervals()` helper method
- Adds `onUninit()` lifecycle hook that calls `clearIntervals()`, preventing timer leaks during app restarts
- Refactors `onDeleted()` to use the same helper

Closes #10