### PR TITLE
chore: gitignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .claude/
 app.json
 .homeybuild/
+.DS_Store


### PR DESCRIPTION
## Summary
- Adds `.DS_Store` to `.gitignore` to prevent macOS metadata files from being committed.

Closes #13