### PR TITLE
feat: add unit tests for core logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@types/node": "^25.5.0",
         "eslint": "^7.32.0",
         "eslint-config-athom": "^3.1.5",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -130,6 +131,40 @@
         "node": ">=4"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -217,6 +252,30 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -255,6 +314,278 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -262,10 +593,53 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node16": {
       "version": "16.1.8",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.8.tgz",
       "integrity": "sha512-T/CfdwFry660WjZor56z0F3pxeCllt8KOxWcHFW6ZEuULKUObTDEMdgtctyuJPxwqyWDsvHRfxHaJ4FIICyoqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
@@ -307,6 +681,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -566,6 +941,119 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.1",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.1",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.1",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -785,6 +1273,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -912,6 +1410,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -960,6 +1468,13 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1091,6 +1606,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dir-glob": {
@@ -1243,6 +1768,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -1787,6 +2319,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1795,6 +2337,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1932,6 +2484,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2827,6 +3394,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2840,6 +3668,16 @@
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -2904,6 +3742,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -3025,6 +3882,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3121,6 +3989,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3149,6 +4024,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -3333,6 +4237,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
       }
     },
     "node_modules/run-parallel": {
@@ -3575,6 +4513,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3603,12 +4548,36 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -3808,6 +4777,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3846,6 +4891,14 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4009,6 +5062,192 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.11",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4112,6 +5351,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint --ext .js,.ts --ignore-path .gitignore ."
+    "lint": "eslint --ext .js,.ts --ignore-path .gitignore .",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@tsconfig/node16": "^16.1.8",
@@ -11,6 +12,7 @@
     "@types/node": "^25.5.0",
     "eslint": "^7.32.0",
     "eslint-config-athom": "^3.1.5",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.1"
   }
 }

--- a/test/OhmeApi.test.ts
+++ b/test/OhmeApi.test.ts
@@ -1,0 +1,464 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OhmeApi, AuthException } from '../lib/OhmeApi';
+import { ChargerStatus, ChargerMode } from '../lib/types';
+
+// Mock fetch globally to prevent any real network calls
+vi.stubGlobal('fetch', vi.fn());
+
+function createApi(): OhmeApi {
+  return new OhmeApi('test@example.com', 'password');
+}
+
+function setChargeSession(api: OhmeApi, session: any): void {
+  (api as any)._chargeSession = session;
+}
+
+function setConfiguration(api: OhmeApi, config: Record<string, boolean | string>): void {
+  (api as any)._configuration = config;
+}
+
+function setCapabilities(api: OhmeApi, caps: Record<string, boolean | string | string[]>): void {
+  (api as any)._capabilities = caps;
+}
+
+function setNextSession(api: OhmeApi, rule: any): void {
+  (api as any)._nextSession = rule;
+}
+
+function setLastRule(api: OhmeApi, rule: any): void {
+  (api as any)._lastRule = rule;
+}
+
+// ── Constructor ──────────────────────────────────────────────────────
+
+describe('OhmeApi constructor', () => {
+  it('throws AuthException when email is empty', () => {
+    expect(() => new OhmeApi('')).toThrow(AuthException);
+  });
+
+  it('accepts email without password', () => {
+    const api = new OhmeApi('test@example.com');
+    expect(api).toBeInstanceOf(OhmeApi);
+  });
+});
+
+// ── Status getter ────────────────────────────────────────────────────
+
+describe('OhmeApi.status', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns unplugged for DISCONNECTED', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    expect(api.status).toBe(ChargerStatus.UNPLUGGED);
+  });
+
+  it('returns pending_approval for PENDING_APPROVAL', () => {
+    setChargeSession(api, { mode: 'PENDING_APPROVAL' });
+    expect(api.status).toBe(ChargerStatus.PENDING_APPROVAL);
+  });
+
+  it('returns paused for STOPPED', () => {
+    setChargeSession(api, { mode: 'STOPPED' });
+    expect(api.status).toBe(ChargerStatus.PAUSED);
+  });
+
+  it('returns finished for FINISHED_CHARGE', () => {
+    setChargeSession(api, { mode: 'FINISHED_CHARGE' });
+    expect(api.status).toBe(ChargerStatus.FINISHED);
+  });
+
+  it('returns charging when power > 0 and mode is not in API_MODE_TO_STATUS', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 7200, amp: 32, volt: 230 } });
+    expect(api.status).toBe(ChargerStatus.CHARGING);
+  });
+
+  it('returns plugged_in when power is 0 and mode is not in API_MODE_TO_STATUS', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 0, amp: 0, volt: null } });
+    expect(api.status).toBe(ChargerStatus.PLUGGED_IN);
+  });
+
+  it('returns plugged_in when no power data and mode is not in API_MODE_TO_STATUS', () => {
+    setChargeSession(api, { mode: 'MAX_CHARGE' });
+    expect(api.status).toBe(ChargerStatus.PLUGGED_IN);
+  });
+});
+
+// ── Mode getter ──────────────────────────────────────────────────────
+
+describe('OhmeApi.mode', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns smart_charge for SMART_CHARGE', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE' });
+    expect(api.mode).toBe(ChargerMode.SMART_CHARGE);
+  });
+
+  it('returns max_charge for MAX_CHARGE', () => {
+    setChargeSession(api, { mode: 'MAX_CHARGE' });
+    expect(api.mode).toBe(ChargerMode.MAX_CHARGE);
+  });
+
+  it('returns paused for STOPPED', () => {
+    setChargeSession(api, { mode: 'STOPPED' });
+    expect(api.mode).toBe(ChargerMode.PAUSED);
+  });
+
+  it('returns null for unmapped modes', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    expect(api.mode).toBeNull();
+  });
+});
+
+// ── isConnected / isCharging ─────────────────────────────────────────
+
+describe('OhmeApi.isConnected', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns false when UNPLUGGED (DISCONNECTED)', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    expect(api.isConnected).toBe(false);
+  });
+
+  it('returns false when PENDING_APPROVAL', () => {
+    setChargeSession(api, { mode: 'PENDING_APPROVAL' });
+    expect(api.isConnected).toBe(false);
+  });
+
+  it('returns true when CHARGING', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 7200, amp: 32, volt: 230 } });
+    expect(api.isConnected).toBe(true);
+  });
+
+  it('returns true when PLUGGED_IN', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 0, amp: 0, volt: null } });
+    expect(api.isConnected).toBe(true);
+  });
+
+  it('returns true when PAUSED (STOPPED)', () => {
+    setChargeSession(api, { mode: 'STOPPED' });
+    expect(api.isConnected).toBe(true);
+  });
+
+  it('returns true when FINISHED', () => {
+    setChargeSession(api, { mode: 'FINISHED_CHARGE' });
+    expect(api.isConnected).toBe(true);
+  });
+});
+
+describe('OhmeApi.isCharging', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns true when actively charging', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 7200, amp: 32, volt: 230 } });
+    expect(api.isCharging).toBe(true);
+  });
+
+  it('returns false when plugged in but not charging', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 0, amp: 0, volt: null } });
+    expect(api.isCharging).toBe(false);
+  });
+
+  it('returns false when disconnected', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    expect(api.isCharging).toBe(false);
+  });
+});
+
+// ── Slot merging ─────────────────────────────────────────────────────
+
+describe('OhmeApi.slots', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns empty array when no session slots', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    expect(api.slots).toEqual([]);
+  });
+
+  it('returns empty array when allSessionSlots is empty', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', allSessionSlots: [] });
+    expect(api.slots).toEqual([]);
+  });
+
+  it('returns single slot correctly', () => {
+    const start = new Date('2026-03-23T01:00:00Z').getTime();
+    const end = new Date('2026-03-23T02:00:00Z').getTime();
+    setChargeSession(api, {
+      mode: 'SMART_CHARGE',
+      allSessionSlots: [{ startTimeMs: start, endTimeMs: end, watts: 7200 }],
+    });
+
+    const slots = api.slots;
+    expect(slots).toHaveLength(1);
+    expect(slots[0].start).toEqual(new Date(start));
+    expect(slots[0].end).toEqual(new Date(end));
+    expect(slots[0].energy).toBe(7.2); // 7200W * 1h / 1000
+  });
+
+  it('merges adjacent slots', () => {
+    const t0 = new Date('2026-03-23T01:00:00Z').getTime();
+    const t1 = new Date('2026-03-23T02:00:00Z').getTime();
+    const t2 = new Date('2026-03-23T03:00:00Z').getTime();
+
+    setChargeSession(api, {
+      mode: 'SMART_CHARGE',
+      allSessionSlots: [
+        { startTimeMs: t0, endTimeMs: t1, watts: 7200 },
+        { startTimeMs: t1, endTimeMs: t2, watts: 7200 },
+      ],
+    });
+
+    const slots = api.slots;
+    expect(slots).toHaveLength(1);
+    expect(slots[0].start).toEqual(new Date(t0));
+    expect(slots[0].end).toEqual(new Date(t2));
+    expect(slots[0].energy).toBe(14.4); // 7.2 + 7.2
+  });
+
+  it('does not merge non-adjacent slots', () => {
+    const t0 = new Date('2026-03-23T01:00:00Z').getTime();
+    const t1 = new Date('2026-03-23T02:00:00Z').getTime();
+    const t2 = new Date('2026-03-23T04:00:00Z').getTime();
+    const t3 = new Date('2026-03-23T05:00:00Z').getTime();
+
+    setChargeSession(api, {
+      mode: 'SMART_CHARGE',
+      allSessionSlots: [
+        { startTimeMs: t0, endTimeMs: t1, watts: 7200 },
+        { startTimeMs: t2, endTimeMs: t3, watts: 3600 },
+      ],
+    });
+
+    const slots = api.slots;
+    expect(slots).toHaveLength(2);
+    expect(slots[0].energy).toBe(7.2);
+    expect(slots[1].energy).toBe(3.6);
+  });
+
+  it('merges multiple consecutive adjacent slots', () => {
+    const t0 = new Date('2026-03-23T01:00:00Z').getTime();
+    const t1 = new Date('2026-03-23T01:30:00Z').getTime();
+    const t2 = new Date('2026-03-23T02:00:00Z').getTime();
+    const t3 = new Date('2026-03-23T02:30:00Z').getTime();
+
+    setChargeSession(api, {
+      mode: 'SMART_CHARGE',
+      allSessionSlots: [
+        { startTimeMs: t0, endTimeMs: t1, watts: 7200 },
+        { startTimeMs: t1, endTimeMs: t2, watts: 7200 },
+        { startTimeMs: t2, endTimeMs: t3, watts: 7200 },
+      ],
+    });
+
+    const slots = api.slots;
+    expect(slots).toHaveLength(1);
+    expect(slots[0].start).toEqual(new Date(t0));
+    expect(slots[0].end).toEqual(new Date(t3));
+    // 3 x 0.5h x 7200W / 1000 = 10.8
+    expect(slots[0].energy).toBe(10.8);
+  });
+});
+
+// ── Target time formatting ───────────────────────────────────────────
+
+describe('OhmeApi.targetTimeFormatted', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('formats 0 seconds as 00:00', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 100, amp: 1, volt: 230 }, appliedRule: { targetTime: 0, targetPercent: 80 } });
+    expect(api.targetTimeFormatted).toBe('00:00');
+  });
+
+  it('formats 3600 seconds as 01:00', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 100, amp: 1, volt: 230 }, appliedRule: { targetTime: 3600, targetPercent: 80 } });
+    expect(api.targetTimeFormatted).toBe('01:00');
+  });
+
+  it('formats 5400 seconds as 01:30', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 100, amp: 1, volt: 230 }, appliedRule: { targetTime: 5400, targetPercent: 80 } });
+    expect(api.targetTimeFormatted).toBe('01:30');
+  });
+
+  it('formats 86340 seconds as 23:59', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 100, amp: 1, volt: 230 }, appliedRule: { targetTime: 86340, targetPercent: 80 } });
+    expect(api.targetTimeFormatted).toBe('23:59');
+  });
+
+  it('uses nextSession when disconnected', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    setNextSession(api, { targetTime: 25200, targetPercent: 80 });
+    expect(api.targetTimeFormatted).toBe('07:00');
+  });
+});
+
+// ── configurationValue / configurationBoolean / isCapable ────────────
+
+describe('OhmeApi.configurationValue', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns boolean value as-is', () => {
+    setConfiguration(api, { lockEnabled: true });
+    expect(api.configurationValue('lockEnabled')).toBe(true);
+  });
+
+  it('returns string value as-is', () => {
+    setConfiguration(api, { ledBrightness: 'high' });
+    expect(api.configurationValue('ledBrightness')).toBe('high');
+  });
+
+  it('returns undefined for missing key', () => {
+    setConfiguration(api, {});
+    expect(api.configurationValue('nonexistent')).toBeUndefined();
+  });
+});
+
+describe('OhmeApi.configurationBoolean', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns true for boolean true', () => {
+    setConfiguration(api, { lockEnabled: true });
+    expect(api.configurationBoolean('lockEnabled')).toBe(true);
+  });
+
+  it('returns false for boolean false', () => {
+    setConfiguration(api, { lockEnabled: false });
+    expect(api.configurationBoolean('lockEnabled')).toBe(false);
+  });
+
+  it('parses string "true" as true', () => {
+    setConfiguration(api, { lockEnabled: 'true' });
+    expect(api.configurationBoolean('lockEnabled')).toBe(true);
+  });
+
+  it('parses string "TRUE" as true (case insensitive)', () => {
+    setConfiguration(api, { lockEnabled: 'TRUE' });
+    expect(api.configurationBoolean('lockEnabled')).toBe(true);
+  });
+
+  it('parses string "false" as false', () => {
+    setConfiguration(api, { lockEnabled: 'false' });
+    expect(api.configurationBoolean('lockEnabled')).toBe(false);
+  });
+
+  it('returns false for missing key', () => {
+    setConfiguration(api, {});
+    expect(api.configurationBoolean('nonexistent')).toBe(false);
+  });
+});
+
+describe('OhmeApi.isCapable', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns true for truthy capability', () => {
+    setCapabilities(api, { solarBoost: true });
+    expect(api.isCapable('solarBoost')).toBe(true);
+  });
+
+  it('returns false for falsy capability', () => {
+    setCapabilities(api, { solarBoost: false });
+    expect(api.isCapable('solarBoost')).toBe(false);
+  });
+
+  it('returns false for missing capability', () => {
+    setCapabilities(api, {});
+    expect(api.isCapable('nonexistent')).toBe(false);
+  });
+});
+
+// ── Power / voltage / current getters ────────────────────────────────
+
+describe('OhmeApi power getters', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns power from session', () => {
+    setChargeSession(api, { mode: 'SMART_CHARGE', power: { watt: 7200, amp: 32, volt: 230 } });
+    expect(api.power).toBe(7200);
+    expect(api.current).toBe(32);
+    expect(api.voltage).toBe(230);
+  });
+
+  it('returns 0/null when no power data', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    expect(api.power).toBe(0);
+    expect(api.current).toBe(0);
+    expect(api.voltage).toBeNull();
+  });
+});
+
+// ── targetSoc ────────────────────────────────────────────────────────
+
+describe('OhmeApi.targetSoc', () => {
+  let api: OhmeApi;
+
+  beforeEach(() => {
+    api = createApi();
+  });
+
+  it('returns appliedRule targetPercent when connected', () => {
+    setChargeSession(api, {
+      mode: 'SMART_CHARGE',
+      power: { watt: 100, amp: 1, volt: 230 },
+      appliedRule: { targetPercent: 80, targetTime: 3600 },
+    });
+    expect(api.targetSoc).toBe(80);
+  });
+
+  it('returns suspendedRule targetPercent when paused', () => {
+    setChargeSession(api, {
+      mode: 'STOPPED',
+      suspendedRule: { targetPercent: 90 },
+    });
+    expect(api.targetSoc).toBe(90);
+  });
+
+  it('returns nextSession targetPercent when disconnected', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    setNextSession(api, { targetPercent: 75 });
+    expect(api.targetSoc).toBe(75);
+  });
+
+  it('returns 0 when no rule info available', () => {
+    setChargeSession(api, { mode: 'DISCONNECTED' });
+    setNextSession(api, {});
+    expect(api.targetSoc).toBe(0);
+  });
+});

--- a/test/OhmeDriver.test.ts
+++ b/test/OhmeDriver.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { OhmeDriver } from '../lib/OhmeDriver';
+
+// Create a test harness that exposes matchesModel as public
+class TestableDriver extends OhmeDriver {
+  constructor(patterns: string[]) {
+    super();
+    this.modelPatterns = patterns;
+  }
+
+  public testMatchesModel(displayName: string): boolean {
+    return this.matchesModel(displayName);
+  }
+}
+
+// Replicate the custom matchesModel from OhmeHomeDriver
+class TestableHomeDriver extends OhmeDriver {
+  constructor() {
+    super();
+    this.modelPatterns = ['Home'];
+  }
+
+  protected matchesModel(displayName: string): boolean {
+    const lower = displayName.toLowerCase();
+    return lower.includes('home') && !lower.includes('pro');
+  }
+
+  public testMatchesModel(displayName: string): boolean {
+    return this.matchesModel(displayName);
+  }
+}
+
+// Replicate the custom matchesModel from OhmeGoDriver
+class TestableGoDriver extends OhmeDriver {
+  constructor() {
+    super();
+    this.modelPatterns = ['Go'];
+  }
+
+  protected matchesModel(displayName: string): boolean {
+    const lower = displayName.toLowerCase();
+    return lower.includes('go') && !lower.includes('pro');
+  }
+
+  public testMatchesModel(displayName: string): boolean {
+    return this.matchesModel(displayName);
+  }
+}
+
+describe('ePod driver matching', () => {
+  const driver = new TestableDriver(['ePod']);
+
+  it('matches "Ohme ePod"', () => {
+    expect(driver.testMatchesModel('Ohme ePod')).toBe(true);
+  });
+
+  it('matches case-insensitively "ohme epod"', () => {
+    expect(driver.testMatchesModel('ohme epod')).toBe(true);
+  });
+
+  it('does not match unrelated model', () => {
+    expect(driver.testMatchesModel('Tesla Wall Connector')).toBe(false);
+  });
+
+  it('does not match "Ohme Home Pro"', () => {
+    expect(driver.testMatchesModel('Ohme Home Pro')).toBe(false);
+  });
+});
+
+describe('Home Pro driver matching', () => {
+  const driver = new TestableDriver(['Home Pro']);
+
+  it('matches "Ohme Home Pro"', () => {
+    expect(driver.testMatchesModel('Ohme Home Pro')).toBe(true);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(driver.testMatchesModel('ohme home pro')).toBe(true);
+  });
+
+  it('does not match "Ohme Home" (without Pro)', () => {
+    expect(driver.testMatchesModel('Ohme Home')).toBe(false);
+  });
+});
+
+describe('Home driver matching (excludes Pro)', () => {
+  const driver = new TestableHomeDriver();
+
+  it('matches "Ohme Home"', () => {
+    expect(driver.testMatchesModel('Ohme Home')).toBe(true);
+  });
+
+  it('does not match "Ohme Home Pro"', () => {
+    expect(driver.testMatchesModel('Ohme Home Pro')).toBe(false);
+  });
+
+  it('does not match unrelated model', () => {
+    expect(driver.testMatchesModel('Tesla Wall Connector')).toBe(false);
+  });
+});
+
+describe('Go driver matching (excludes Pro)', () => {
+  const driver = new TestableGoDriver();
+
+  it('matches "Ohme Go"', () => {
+    expect(driver.testMatchesModel('Ohme Go')).toBe(true);
+  });
+
+  it('does not match unrelated model', () => {
+    expect(driver.testMatchesModel('Tesla Wall Connector')).toBe(false);
+  });
+});

--- a/test/mocks/homey.ts
+++ b/test/mocks/homey.ts
@@ -1,0 +1,16 @@
+class Driver {
+  log(..._args: any[]) {}
+  error(..._args: any[]) {}
+}
+
+class App {
+  log(..._args: any[]) {}
+  error(..._args: any[]) {}
+}
+
+class Device {
+  log(..._args: any[]) {}
+  error(..._args: any[]) {}
+}
+
+export default { Driver, App, Device };

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ChargerStatus,
+  ChargerMode,
+  API_MODE_TO_STATUS,
+  API_MODE_TO_CHARGER_MODE,
+} from '../lib/types';
+
+describe('API_MODE_TO_STATUS', () => {
+  it('maps PENDING_APPROVAL to pending_approval', () => {
+    expect(API_MODE_TO_STATUS['PENDING_APPROVAL']).toBe(ChargerStatus.PENDING_APPROVAL);
+  });
+
+  it('maps DISCONNECTED to unplugged', () => {
+    expect(API_MODE_TO_STATUS['DISCONNECTED']).toBe(ChargerStatus.UNPLUGGED);
+  });
+
+  it('maps STOPPED to paused', () => {
+    expect(API_MODE_TO_STATUS['STOPPED']).toBe(ChargerStatus.PAUSED);
+  });
+
+  it('maps FINISHED_CHARGE to finished', () => {
+    expect(API_MODE_TO_STATUS['FINISHED_CHARGE']).toBe(ChargerStatus.FINISHED);
+  });
+
+  it('does not map unknown modes', () => {
+    expect(API_MODE_TO_STATUS['SMART_CHARGE']).toBeUndefined();
+    expect(API_MODE_TO_STATUS['MAX_CHARGE']).toBeUndefined();
+  });
+});
+
+describe('API_MODE_TO_CHARGER_MODE', () => {
+  it('maps SMART_CHARGE to smart_charge', () => {
+    expect(API_MODE_TO_CHARGER_MODE['SMART_CHARGE']).toBe(ChargerMode.SMART_CHARGE);
+  });
+
+  it('maps MAX_CHARGE to max_charge', () => {
+    expect(API_MODE_TO_CHARGER_MODE['MAX_CHARGE']).toBe(ChargerMode.MAX_CHARGE);
+  });
+
+  it('maps STOPPED to paused', () => {
+    expect(API_MODE_TO_CHARGER_MODE['STOPPED']).toBe(ChargerMode.PAUSED);
+  });
+
+  it('does not map unknown modes', () => {
+    expect(API_MODE_TO_CHARGER_MODE['DISCONNECTED']).toBeUndefined();
+    expect(API_MODE_TO_CHARGER_MODE['FINISHED_CHARGE']).toBeUndefined();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "allowJs": true,
     "outDir": ".homeybuild/"
-  }
+  },
+  "exclude": [
+    "vitest.config.ts",
+    "test/**/*"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    alias: {
+      'homey': path.resolve(__dirname, 'test/mocks/homey.ts'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Adds vitest as test framework with Homey SDK mock alias
- 72 unit tests covering: status/mode mapping, model matching, slot merging, target time formatting, isConnected/isCharging logic, configuration getters, power getters, and targetSoc

## Test plan

- [x] `npm test` passes all 72 tests
- [ ] Verify no regressions in existing build (`npm run build`)

Closes #14